### PR TITLE
feat: add scala (Secure Calendar App) to workspace

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,13 @@
       inputs.nix-bundle-macos-app.follows = "nix-bundle-macos-app";
     };
 
+    # ── Scala — Secure Calendar App ───────────────────────────────────────────
+    scala = {
+      url = "github:jimmy-claw/scala";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.logos-module-builder.follows = "logos-module-builder";
+    };
+
     # ── Modules: Accounts ─────────────────────────────────────────────────────
 
     logos-accounts-module = {
@@ -393,6 +400,8 @@
         "logos-js-sdk" "logos-nim-sdk" "logos-rust-sdk"
         # Other
         "logos-modules" "logos-module-viewer"
+        # Scala
+        "scala"
       ];
 
       # Mapping from flake input name → submodule directory name under repos/

--- a/nix/dep-graph.nix
+++ b/nix/dep-graph.nix
@@ -38,6 +38,7 @@
   logos-wallet-ui              = { deps = [ "logos-cpp-sdk" "logos-liblogos" "logos-capability-module" "logos-wallet-module" ]; hasTests = false; };
   logos-libp2p-module          = { deps = [ "logos-module-builder" ]; hasTests = true; };
   logos-simple-module          = { deps = []; hasTests = true; };
+  scala                        = { deps = ["logos-module-builder" "logos-liblogos"]; hasTests = true; };
   logos-webview-app            = { deps = [ "logos-cpp-sdk" "logos-liblogos" ]; hasTests = false; };
   counter_qml                  = { deps = [ "logos-cpp-sdk" ]; hasTests = false; };
   counter                      = { deps = [ "logos-cpp-sdk" ]; hasTests = false; };

--- a/scripts/ws
+++ b/scripts/ws
@@ -95,6 +95,9 @@ REPOS=(
   "logos-nim-sdk|logos-nim-sdk|https://github.com/logos-co/logos-nim-sdk.git|yes"
   "logos-rust-sdk|logos-rust-sdk|https://github.com/logos-co/logos-rust-sdk.git|yes"
 
+  # Scala — Secure Calendar App
+  "scala|scala|https://github.com/jimmy-claw/scala.git|yes"
+
   # Other
   "logos-modules|logos-modules|https://github.com/logos-co/logos-modules.git|yes"
   "logos-module-viewer|logos-module-viewer|https://github.com/logos-co/logos-module-viewer.git|yes"


### PR DESCRIPTION
Adds [jimmy-claw/scala](https://github.com/jimmy-claw/scala) — a privacy-first shared calendar app built on Logos Core — to the workspace.

## Changes

- **`flake.nix`** — new `scala` input with `nixpkgs` + `logos-module-builder` follows
- **`scripts/ws`** — `scala` added to `REPOS` list  
- **`nix/dep-graph.nix`** — `scala` with deps `[logos-module-builder, logos-liblogos]`

## Why

Scala implements the full Logos module pattern:
- `scala_module` — headless logoscore plugin (C++/Qt, `PluginInterface`)
- `ScalaUIComponent` — `IComponent` for loading in logos-app-poc
- Uses `kv_module` for storage, `accounts_module` + `messaging_module` optionally

Adding it to the workspace enables:
```bash
ws build scala                           # build the module
ws test scala                            # run 50+ tests
ws build logos-app-poc --local scala     # test IComponent in logos-app-poc
ws run logos-app-poc --local scala       # run app with Scala loaded
```

## Note on submodule

The actual `git submodule add` needs to be done by a maintainer with write access:
```bash
git submodule add --depth 1 https://github.com/jimmy-claw/scala.git repos/scala
ws sync-graph
```

Happy to transfer the repo to `logos-co` org if preferred.