### PR TITLE
support all flake outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -458,18 +458,31 @@
     in {
 
       # ── Packages ──────────────────────────────────────────────────────────
-      # nix build .#logos-cpp-sdk
-      # nix build .#logos-basecamp
+      # nix build .#logos-cpp-sdk          → default package
+      # nix build .#logos-basecamp          → default package
+      # nix build .#logos-basecamp--portable → non-default output
+      # nix build .#logos-liblogos--portable
+      # All repo package outputs are exposed: default as the repo name,
+      # non-default as <repo>--<output>.
       packages = forAllSystems (system:
-        builtins.listToAttrs (builtins.concatMap (name:
-          let
-            result = builtins.tryEval (
-              (inputs.${name}.packages.${system} or {}).default or null
-            );
-            pkg = if result.success then result.value else null;
-          in
-          if pkg != null then [{ inherit name; value = pkg; }] else []
-        ) repoInputNames)
+        let
+          # Collect all package outputs from all repos.
+          # Each repo's packages are forwarded lazily — the value is not
+          # evaluated until someone actually builds it, so broken store
+          # paths or missing files won't cause errors at evaluation time.
+          allPkgs = builtins.foldl' (acc: name:
+            let
+              repoPkgs = (inputs.${name}.packages.${system} or {});
+              outNames = builtins.attrNames repoPkgs;
+            in
+            acc // builtins.listToAttrs (map (outName:
+              let
+                attrName = if outName == "default" then name else "${name}--${outName}";
+              in
+              { name = attrName; value = repoPkgs.${outName}; }
+            ) outNames)
+          ) {} repoInputNames;
+        in allPkgs
       );
 
       # ── Dev Shells ────────────────────────────────────────────────────────

--- a/scripts/ws
+++ b/scripts/ws
@@ -329,9 +329,12 @@ Arguments:
 }
 
 cmd_build() {
-  wants_help "$@" && show_help "Usage: ws build <repo...|--group name> [options]
+  wants_help "$@" && show_help "Usage: ws build <repo[#output]...|--group name> [options]
 
 Build one or more repos via nix.
+
+Use repo#output to build a specific flake output instead of the default.
+For example: ws build logos-basecamp#portable
 
 Options:
   --group, -g <name...>         Use a named repo group (see 'ws groups')
@@ -341,10 +344,12 @@ Options:
 
 Examples:
   ws build logos-basecamp
+  ws build logos-basecamp#portable
   ws build logos-basecamp logos-liblogos
   ws build --group core
   ws build logos-basecamp --auto-local
   ws build logos-basecamp --local logos-cpp-sdk logos-liblogos
+  ws build logos-basecamp#bin-bundle-dir --local nix-bundle-lgx logos-liblogos
   ws build logos-basecamp --workspace"
 
   local repos=()
@@ -416,40 +421,65 @@ Examples:
   fi
 
   if [[ ${#repos[@]} -eq 1 ]]; then
+    local repo_spec="${repos[0]}"
+    local repo_name="${repo_spec%%#*}"
+    local output_suffix=""
+    [[ "$repo_spec" == *"#"* ]] && output_suffix="${repo_spec#*#}"
     local input_name
-    input_name=$(get_input_name "${repos[0]}")
+    input_name=$(get_input_name "$repo_name")
     if [[ -z "$input_name" ]]; then
-      echo -e "${RED}Error:${NC} repo '${repos[0]}' has no flake input (non-flake repo)" >&2
+      echo -e "${RED}Error:${NC} repo '$repo_name' has no flake input (non-flake repo)" >&2
       exit 1
     fi
-    log "${BOLD}Building ${CYAN}$input_name${NC}${BOLD}...${NC}"
+    # All repo outputs are exposed through the workspace flake:
+    # default → .#<input_name>, non-default → .#<input_name>--<output>
+    local nix_ref
+    if [[ -n "$output_suffix" ]]; then
+      nix_ref="$WORKSPACE_ROOT#$input_name--$output_suffix"
+    else
+      nix_ref="$WORKSPACE_ROOT#$input_name"
+    fi
+    local display_name="$input_name"
+    [[ -n "$output_suffix" ]] && display_name="$input_name#$output_suffix"
+    log "${BOLD}Building ${CYAN}$display_name${NC}${BOLD}...${NC}"
     exec nix build \
       --extra-experimental-features "nix-command flakes" \
-      "$WORKSPACE_ROOT#$input_name" \
+      "$nix_ref" \
       ${flags[@]+"${flags[@]}"} \
       ${extra_args[@]+"${extra_args[@]}"}
   fi
 
   local failed=0
-  for repo in "${repos[@]}"; do
+  for repo_spec in "${repos[@]}"; do
+    local repo_name="${repo_spec%%#*}"
+    local output_suffix=""
+    [[ "$repo_spec" == *"#"* ]] && output_suffix="${repo_spec#*#}"
     local input_name
-    input_name=$(get_input_name "$repo")
+    input_name=$(get_input_name "$repo_name")
     if [[ -z "$input_name" ]]; then
-      echo -e "${RED}Error:${NC} repo '$repo' has no flake input (non-flake repo)" >&2
+      echo -e "${RED}Error:${NC} repo '$repo_name' has no flake input (non-flake repo)" >&2
       failed=$((failed + 1))
       continue
     fi
+    local nix_ref
+    if [[ -n "$output_suffix" ]]; then
+      nix_ref="$WORKSPACE_ROOT#$input_name--$output_suffix"
+    else
+      nix_ref="$WORKSPACE_ROOT#$input_name"
+    fi
+    local display_name="$input_name"
+    [[ -n "$output_suffix" ]] && display_name="$input_name#$output_suffix"
 
-    log "${BOLD}Building ${CYAN}$input_name${NC}${BOLD}...${NC}"
+    log "${BOLD}Building ${CYAN}$display_name${NC}${BOLD}...${NC}"
     if ! nix build \
       --extra-experimental-features "nix-command flakes" \
-      "$WORKSPACE_ROOT#$input_name" \
+      "$nix_ref" \
       ${flags[@]+"${flags[@]}"} \
       ${extra_args[@]+"${extra_args[@]}"}; then
-      echo -e "${RED}FAIL${NC} $input_name"
+      echo -e "${RED}FAIL${NC} $display_name"
       failed=$((failed + 1))
     else
-      echo -e "${GREEN}OK${NC}   $input_name"
+      echo -e "${GREEN}OK${NC}   $display_name"
     fi
     log ""
   done


### PR DESCRIPTION
Only the default output could be built before. Now we support stuff like `ws build logos-basecamp#bin-bundle-dir`