### PR TITLE
ws: exempt logos-rust-sdk from workspace follows (keep cpp-sdk c_ffi)

### DIFF
--- a/scripts/ws
+++ b/scripts/ws
@@ -2360,6 +2360,22 @@ get_repo_url() {
   esac
 }
 
+# ── Repos that must build from their OWN locked inputs even under
+# --workspace, i.e. sync-graph emits NO workspace `follows` for them.
+# Each entry is a deliberate divergence and must say why.
+follows_exempt() {
+  case "$1" in
+    # logos-rust-sdk's C-FFI codegen needs logos-cpp-sdk's `c_ffi` branch:
+    # the `support c-ffi` commit (d98e2a9) that emits the provider
+    # inter-module API header was never merged to cpp-sdk master. Following
+    # the workspace (master) cpp-sdk breaks the caller module's generated
+    # code (`fatal error: sdk_test_provider_module_api.h: No such file`), so
+    # keep it on its own c_ffi pins. Revisit once c-ffi lands on cpp-sdk master.
+    logos-rust-sdk) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # ── Workspace-level follows that override what each repo's lock would
 # otherwise produce.  Every entry is a deliberate divergence from upstream
 # and should have a comment explaining why.  Returns tab-separated
@@ -2521,7 +2537,7 @@ HEADER
     # `follows_pairs` is a single multi-line string (bash 3.2 has no
     # associative arrays).  Lines are sorted alphabetically by iname later.
     local follows_pairs=""
-    if [[ -f "$lock_file" ]]; then
+    if ! follows_exempt "$input_name" && [[ -f "$lock_file" ]]; then
       # jq emits one tab-separated record per root input:
       #   <kind>\t<input_name>\t<repo>\t<dir>
       # where <kind> is "url" (string ref to a node) or "follows" (array ref,


### PR DESCRIPTION
## Summary

With the crates.io 403 fixed (logos-rust-sdk#10, merged), the nightly bump's `logos-rust-sdk` ipc-test now fails one step later:

```
/build/caller/generated_code/include/logos_sdk.h:5:10: fatal error:
  sdk_test_provider_module_api.h: No such file or directory
```

**Cause — a cpp-sdk branch divergence.** logos-rust-sdk pins `logos-module-builder/c_ffi` → `logos-cpp-sdk/c_ffi`. The C-FFI codegen support that emits the provider's inter-module API header is the commit `d98e2a9 "support c-ffi"`, which lives **only on cpp-sdk's `c_ffi` branch and was never merged to master** (`c_ffi` = master-of-2026-04-22 + that one commit; master is 20 commits ahead without it).

`ws test --all --workspace` propagates the workspace's **master** cpp-sdk into rust-sdk via `follows`, so its caller codegen breaks. It builds fine **standalone** (its own `c_ffi` pins) — verified: `call_add(5,3) -> 8`.

## Change

Add a `follows_exempt` list to `scripts/ws` and skip auto-`follows` generation for listed repos, so `ws sync-graph` emits `follows = {}` for `logos-rust-sdk`. It then builds from its own `c_ffi`-based lock even under `--workspace` (the configuration that passes standalone). Verified locally — regenerated `dep-graph.nix` shows `logos-rust-sdk = { deps = []; follows = {}; ... }`.

Combined with the merged cargoLock fix, rust-sdk gets both halves: vendor via fetchurl (no 403) **and** `c_ffi` cpp-sdk (codegen works).

> This is an interim workaround. The real fix is merging `support c-ffi` onto cpp-sdk master, after which rust-sdk can drop its `c_ffi` pins and this exemption can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)