### PR TITLE
ci: bump install-nix-action v27 → v31.11.0 (Nix 2.22 → 2.35.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
 
       - name: Install Nix
         if: steps.filter.outputs.skip_build != 'true'
-        uses: cachix/install-nix-action@v27
+        # Nix 2.35.1. Must stay >= 2.26: below that, `--override-input` DISCARDS the
+        # overridden input's own lock and resolves its children from the parent's stale
+        # lock, so a doc-test that overrides an input can silently build months-old deps
+        # and still report green. v27 shipped 2.22 and did exactly that.
+        uses: cachix/install-nix-action@v31.11.0
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/nightly-bump.yml
+++ b/.github/workflows/nightly-bump.yml
@@ -91,7 +91,11 @@ jobs:
 
       - name: Install Nix
         if: steps.check.outputs.changed == 'true'
-        uses: cachix/install-nix-action@v27
+        # Nix 2.35.1. Must stay >= 2.26: below that, `--override-input` DISCARDS the
+        # overridden input's own lock and resolves its children from the parent's stale
+        # lock, so a doc-test that overrides an input can silently build months-old deps
+        # and still report green. v27 shipped 2.22 and did exactly that.
+        uses: cachix/install-nix-action@v31.11.0
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/tests-and-doctests.yml
+++ b/.github/workflows/tests-and-doctests.yml
@@ -226,7 +226,11 @@ jobs:
           git submodule update --init --depth 1 --jobs 4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        # Nix 2.35.1. Must stay >= 2.26: below that, `--override-input` DISCARDS the
+        # overridden input's own lock and resolves its children from the parent's stale
+        # lock, so a doc-test that overrides an input can silently build months-old deps
+        # and still report green. v27 shipped 2.22 and did exactly that.
+        uses: cachix/install-nix-action@v31.11.0
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes


### PR DESCRIPTION
Nix below **2.26** discards an overridden input's own lock and resolves its children from the **parent's** lock instead. Every doc-test that passes `--override-input` — which is all of them under `--workspace-pins` — therefore builds that input's dependencies from a stale snapshot, and can silently compile months-old code **while reporting green**. `v27` shipped Nix 2.22.

## Not theoretical

On #99 this produced two failures whose builds are clean on a local Nix 2.34.6 with the **identical** pins:

| job | CI (Nix 2.22) | local (Nix 2.34.6) |
|---|---|---|
| `doctest logos-basecamp` (both platforms) | `#include "logos_async_result.h"` — file not found | `nix build .#logos-basecamp` **succeeds** |
| `doctest logos-tutorial` (both platforms) | 6 failures, all downstream of the basecamp build | — |

The basecamp artifact built locally carries the expected new-protocol symbols (`ModuleHandshakeProxy` ×160, `seedHandshakeTrustAnchor` ×10), so the pins are sound; CI just could not resolve them. Same pins, opposite outcomes, decided entirely by the Nix version.

The same root cause also forced an otherwise-unnecessary pin on #99: `logos-lidl` had to be bumped because cpp-sdk's own lidl pin was being discarded in favour of the parent's stale one.

## Why it matters beyond #99

The workspace job exists to catch cross-repo drift. Under Nix 2.22 it can build a dependency at a commit the workspace does not pin and still pass — the failure mode `--workspace-pins` was introduced to eliminate. This silently under-tests every doc-test that overrides an input.

## Scope

Version bump only — `v31` keeps the `extra_nix_config` interface, and the diff is 3 lines of `uses:` plus a comment explaining the ≥ 2.26 floor so it is not casually reverted.

Applied to **all three** workflows (`tests-and-doctests.yml`, `ci.yml`, `nightly-bump.yml`) deliberately: a doc-test that resolves its inputs differently in `ci.yml` than in `tests-and-doctests.yml` is its own trap.

## Verification plan

Merge this first, then rebase #99 onto it and re-run `tests-and-doctests`. Expected: both `logos-basecamp` jobs and the 6 remaining `logos-tutorial` failures clear. The other reds on #99 are independent and will remain — `logos-storage-module` (86/1, identical pre-existing), `logos-execution-zone-module` (10/13 pre-existing; Metal Toolchain on macOS), and `logos-evm-wallet-ui` (logos-co/logos-doctest#12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)